### PR TITLE
Use cc instead of gcc in make.sh

### DIFF
--- a/make.sh
+++ b/make.sh
@@ -1,1 +1,1 @@
-gcc -o weebasic weebasic.c
+cc -o weebasic weebasic.c


### PR DESCRIPTION
People on Macs tend to have clang and Linux people tend to have gcc.
Use `cc` which is an alias for either.