### PR TITLE
Add insn debugger

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,3 +71,9 @@ To get a backtrace, you can set the `RUST_BACKTRACE` environment variable:
 ```
 RUST_BACKTRACE=1 ./weebasic example.bas
 ```
+
+You can also set the `RUST_LOG` environment variable to see `debug!` outputs:
+
+```
+RUST_LOG=debug ./weebasic example.bas
+```

--- a/weebasic.rs
+++ b/weebasic.rs
@@ -14,6 +14,7 @@
 use std::io;
 use std::io::Write;
 use std::env;
+use std::fmt;
 use std::fs;
 use std::collections::HashMap;
 
@@ -76,6 +77,13 @@ struct Insn
     imm: Value,
 }
 
+impl fmt::Debug for Insn {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Insn {{ op: {:10} imm: {:?} }}", format!("{:?},", self.op), self.imm)
+    }
+}
+
+#[derive(Debug)]
 struct Program
 {
     /// List of instructions
@@ -513,6 +521,11 @@ fn parse_file(file_name: &str) -> Program
     return program;
 }
 
+// A quick immitation of env_logger crate that enables logging with RUST_LOG=debug
+macro_rules! debug {
+    ($($arg:tt)+) => (if env::var("RUST_LOG").is_ok() { println!($($arg)+) })
+}
+
 /// Virtual machine / interpreter
 struct VM
 {
@@ -556,6 +569,7 @@ impl VM
         while self.pc < prog.insns.len() {
             // Read the current instruction
             let insn = &prog.insns[self.pc];
+            debug!("{:3}: {:?}", self.pc, insn);
 
             match insn.op
             {
@@ -669,6 +683,7 @@ fn main()
     if args.len() == 2 {
         // Parse the source file
         let prog = parse_file(&args[1]);
+        debug!("{:#?}", prog);
 
         // Evaluate the program
         let mut vm = VM::new();


### PR DESCRIPTION
This is what I found useful when playing with this interpreter.

Pretty printing `Program` with `{:#?}` and `#[derive(Derive)]` works okay, but I wanted to see each instruction in a single line. So I added a manual implementation of `Debug` trait for `Insn`.

While I initially used that through bare `println!`, in this pull request, I added a `debug!` macro, which is an imitation of [log](https://github.com/rust-lang/log) and [env_logger](https://github.com/env-logger-rs/env_logger) crates, so that you can optionally enable it via `RUST_LOG` environment variable.

## Example

```
$ rustc weebasic.rs && RUST_LOG=debug ./weebasic example.bas
["./weebasic", "example.bas"]
Program {
    insns: [
        Insn { op: Push,      imm: IntVal(76) },
        Insn { op: SetLocal,  imm: Idx(0) },
        Insn { op: Push,      imm: IntVal(33) },
        Insn { op: SetLocal,  imm: Idx(1) },
        Insn { op: GetLocal,  imm: Idx(0) },
        Insn { op: GetLocal,  imm: Idx(1) },
        Insn { op: Add,       imm: None },
        Insn { op: SetLocal,  imm: Idx(2) },
        Insn { op: Push,      imm: IntVal(35) },
        Insn { op: SetLocal,  imm: Idx(3) },
        Insn { op: ReadInt,   imm: None },
        Insn { op: SetLocal,  imm: Idx(4) },
        Insn { op: GetLocal,  imm: Idx(4) },
        Insn { op: Push,      imm: IntVal(10) },
        Insn { op: LessThan,  imm: None },
        Insn { op: IfNot,     imm: IntVal(6) },
        Insn { op: GetLocal,  imm: Idx(4) },
        Insn { op: Push,      imm: IntVal(1) },
        Insn { op: Add,       imm: None },
        Insn { op: SetLocal,  imm: Idx(5) },
        Insn { op: GetLocal,  imm: Idx(5) },
        Insn { op: Print,     imm: None },
    ],
    local_idxs: {
        "y": 1,
        "z": 2,
        "int_val": 4,
        "x": 0,
        "z2": 3,
        "wx": 5,
    },
}
  0: Insn { op: Push,      imm: IntVal(76) }
  1: Insn { op: SetLocal,  imm: Idx(0) }
  2: Insn { op: Push,      imm: IntVal(33) }
  3: Insn { op: SetLocal,  imm: Idx(1) }
  4: Insn { op: GetLocal,  imm: Idx(0) }
  5: Insn { op: GetLocal,  imm: Idx(1) }
  6: Insn { op: Add,       imm: None }
  7: Insn { op: SetLocal,  imm: Idx(2) }
  8: Insn { op: Push,      imm: IntVal(35) }
  9: Insn { op: SetLocal,  imm: Idx(3) }
 10: Insn { op: ReadInt,   imm: None }
Input an integer value:
> 11
 11: Insn { op: SetLocal,  imm: Idx(4) }
 12: Insn { op: GetLocal,  imm: Idx(4) }
 13: Insn { op: Push,      imm: IntVal(10) }
 14: Insn { op: LessThan,  imm: None }
 15: Insn { op: IfNot,     imm: IntVal(6) }
```